### PR TITLE
Remove convenient methods that hardcode UIApplication's keywindow.  

### DIFF
--- a/Classes/Popover.swift
+++ b/Classes/Popover.swift
@@ -140,9 +140,9 @@ open class Popover: UIView {
     self.frame = frame
   }
 
-  open func show(_ contentView: UIView, fromView: UIView) {
-    self.show(contentView, fromView: fromView, inView: UIApplication.shared.keyWindow!)
-  }
+//  open func show(_ contentView: UIView, fromView: UIView) {
+//    self.show(contentView, fromView: fromView, inView: UIApplication.shared.keyWindow!)
+//  }
 
   open func show(_ contentView: UIView, fromView: UIView, inView: UIView) {
     let point: CGPoint
@@ -155,9 +155,9 @@ open class Popover: UIView {
     self.show(contentView, point: point, inView: inView)
   }
 
-  open func show(_ contentView: UIView, point: CGPoint) {
-    self.show(contentView, point: point, inView: UIApplication.shared.keyWindow!)
-  }
+//  open func show(_ contentView: UIView, point: CGPoint) {
+//    self.show(contentView, point: point, inView: UIApplication.shared.keyWindow!)
+//  }
 
   open func show(_ contentView: UIView, point: CGPoint, inView: UIView) {
     self.blackOverlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/Popover.xcodeproj/project.pbxproj
+++ b/Popover.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		72782A601C6BE5C3003BA478 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -267,6 +268,7 @@
 		72782A611C6BE5C3003BA478 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
- Make it app extension friendly
